### PR TITLE
feat: add devcontainer configuration and post-create script

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,44 @@
+{
+    "name": "Default dev",
+    "image": "mcr.microsoft.com/devcontainers/python:3.14",
+    "customizations": {
+      "codespaces": {
+        "openFiles": [
+          "README.md"
+        ]
+      },
+      "vscode": {
+        "extensions": [
+          "ms-python.python",
+          "GitHub.copilot",
+          "redhat.vscode-yaml",
+          "charliermarsh.ruff",
+          "ms-python.mypy-type-checker",
+          "njpwerner.autodocstring",
+          "ms-vsliveshare.vsliveshare"
+        ],
+        "settings": {
+          "editor.defaultFormatter": "charliermarsh.ruff",
+          "editor.formatOnPaste": false,
+          "editor.formatOnSave": true,
+          "editor.formatOnType": true,
+          "editor.codeActionsOnSave": {
+            "source.fixAll": true
+          },
+          "files.trimTrailingWhitespace": true,
+          "yaml.customTags": [
+            "!input scalar",
+            "!secret scalar",
+            "!include_dir_named scalar",
+            "!include_dir_list scalar",
+            "!include_dir_merge_list scalar",
+            "!include_dir_merge_named scalar"
+          ]
+        }
+      }
+    },
+    "hostRequirements": {
+      "cpus": 2
+    },
+    "postCreateCommand": "./.devcontainer/post-create.sh"
+  }

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,1 @@
+curl -LsSf https://astral.sh/uv/install.sh | sh


### PR DESCRIPTION
This pull request introduces a new development container configuration to streamline the onboarding and setup process for contributors. It adds a `.devcontainer/devcontainer.json` file that defines the development environment, including the base image, recommended VS Code extensions, editor settings, and a post-creation script. Additionally, it adds a post-create script to install the `uv` tool automatically after the container is created.

Development environment setup:

* Added `.devcontainer/devcontainer.json` to define a Python 3.14-based development container, specify recommended VS Code extensions (such as Python, Ruff, Copilot, and YAML tools), and enforce consistent editor settings for formatting and whitespace.
* Configured the container to automatically open `README.md` when starting, and to require at least 2 CPUs on the host machine.

Automation and tooling:

* Added `.devcontainer/post-create.sh` to automatically install the `uv` tool in the development container after creation, ensuring all contributors have the necessary tooling.


related to #1 