### PR TITLE
Build workflow for pyinstaller

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Build executable
         run: |
-          pyinstaller --noconfirm --onefile \
+          uv run pyinstaller --noconfirm --onefile \
             --name DGsUtilityAgency \
             --add-data "$ADD_DATA" \
             main.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Build executables
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Set up Python
+        run: uv python install
+
+      - name: Install build dependencies
+        run: uv sync --extra build
+
+      - name: Configure PyInstaller data paths
+        run: |
+          if [ "${{ runner.os }}" = "Windows" ]; then
+            echo "ADD_DATA=src/application/dgutility.css;src/application" >> $GITHUB_ENV
+            echo "EXE_EXT=.exe" >> $GITHUB_ENV
+          else
+            echo "ADD_DATA=src/application/dgutility.css:src/application" >> $GITHUB_ENV
+            echo "EXE_EXT=" >> $GITHUB_ENV
+          fi
+        shell: bash
+
+      - name: Build executable
+        run: |
+          pyinstaller --noconfirm --onefile \
+            --name DGsUtilityAgency \
+            --add-data "$ADD_DATA" \
+            main.py
+        shell: bash
+
+      # Placeholder for future signing/notarization steps per OS
+      # - name: Sign executable
+      #   run: echo "TODO: add platform-specific signing"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: DGsUtilityAgency-${{ runner.os }}
+          path: dist/DGsUtilityAgency${{ env.EXE_EXT }}
+          if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Build executable
         run: |
           uv run pyinstaller --noconfirm --onefile \
-            --name DGsUtilityAgency \
+            --name DGsUtilityAgency-${{ runner.os }} \
             --add-data "$ADD_DATA" \
             main.py
         shell: bash
@@ -52,5 +52,5 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: DGsUtilityAgency-${{ runner.os }}
-          path: dist/DGsUtilityAgency${{ env.EXE_EXT }}
+          path: dist/DGsUtilityAgency-${{ runner.os }}${{ env.EXE_EXT }}
           if-no-files-found: error

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: Build executables
 
 on:
   workflow_dispatch:
+  workflow_call:
 
 jobs:
   build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,6 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           pattern: DGsUtilityAgency-*
-          merge-multiple: true
           path: artifacts
 
       - name: Debug

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,17 @@ jobs:
           merge-multiple: true
           path: artifacts
 
+      - name: Debug
+        run: |
+          ls
+          cd artifacts
+          ls
+
       - name: Add assets to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-*
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Windows
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Linux
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-macOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,9 @@ jobs:
         uses: actions/download-artifact@v7
         with:
           name: DGsUtilityAgency-*
-      
+
       - name: Add assets to release
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload ${{ github.event.release.tag_name }} ./DGsUtilityAgency-*
+          gh release upload "${TAG_NAME}" ./DGsUtilityAgency-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Windows/DGsUtilityAgency.exe
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Linux/DGsUtilityAgency
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-macOS/DGsUtilityAgency
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Windows/DGsUtilityAgency-Windows.exe
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Linux/DGsUtilityAgency-Linux
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-macOS/DGsUtilityAgency-macOS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,12 @@ jobs:
       - name: Download build artifacts
         uses: actions/download-artifact@v7
         with:
-          name: DGsUtilityAgency-*
+          pattern: DGsUtilityAgency-*
+          merge-multiple: true
+          path: artifacts
 
       - name: Add assets to release
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload "${TAG_NAME}" ./DGsUtilityAgency-*
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.event.release.tag_name }}
-          BASE: artifacts/DGsUtilityAgency-
+          BASE: artifacts/DGsUtilityAgency
         run: |
           gh release upload "${TAG_NAME}" "${BASE}-Windows/DGsUtilityAgency-Windows.exe#DGsUtilityAgency-Windows-${TAG_NAME}.exe"
           gh release upload "${TAG_NAME}" "${BASE}-Linux/DGsUtilityAgency-Linux"#DGsUtilityAgency-Linux-${TAG_NAME}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,25 @@
+name: Add assets to release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+
+  add-assets:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v7
+        with:
+          name: DGsUtilityAgency-*
+      
+      - name: Add assets to release
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} ./DGsUtilityAgency-*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.event.release.tag_name }}
+          BASE: artifacts/DGsUtilityAgency-
         run: |
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Windows/DGsUtilityAgency-Windows.exe
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Linux/DGsUtilityAgency-Linux
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-macOS/DGsUtilityAgency-macOS
+          gh release upload "${TAG_NAME}" "${BASE}-Windows/DGsUtilityAgency-Windows.exe#DGsUtilityAgency-Windows-${TAG_NAME}.exe"
+          gh release upload "${TAG_NAME}" "${BASE}-Linux/DGsUtilityAgency-Linux"#DGsUtilityAgency-Linux-${TAG_NAME}
+          gh release upload "${TAG_NAME}" "${BASE}-macOS/DGsUtilityAgency-macOS"#DGsUtilityAgency-macOS-${TAG_NAME}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,17 +21,11 @@ jobs:
           pattern: DGsUtilityAgency-*
           path: artifacts
 
-      - name: Debug
-        run: |
-          ls
-          cd artifacts
-          ls
-
       - name: Add assets to release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Windows
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Linux
-          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-macOS
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Windows/DGsUtilityAgency.exe
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-Linux/DGsUtilityAgency
+          gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-macOS/DGsUtilityAgency

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Add assets to release
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           gh release upload "${TAG_NAME}" artifacts/DGsUtilityAgency-*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,7 @@ dependencies = [
     "rich>=14.2.0",
     "textual>=6.6.0",
 ]
+[project.optional-dependencies]
+build = [
+  "pyinstaller>=6.17",
+]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "dgsutilityagency"
 version = "0.1.0"
 source = { virtual = "." }
@@ -11,11 +20,18 @@ dependencies = [
     { name = "textual" },
 ]
 
+[package.optional-dependencies]
+build = [
+    { name = "pyinstaller" },
+]
+
 [package.metadata]
 requires-dist = [
+    { name = "pyinstaller", marker = "extra == 'build'", specifier = ">=6.17" },
     { name = "rich", specifier = ">=14.2.0" },
     { name = "textual", specifier = ">=6.6.0" },
 ]
+provides-extras = ["build"]
 
 [[package]]
 name = "linkify-it-py"
@@ -27,6 +43,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2a/ae/bb56c6828e4797ba5a4821eec7c43b8bf40f69cda4d4f5f8c8a2810ec96a/linkify-it-py-2.0.3.tar.gz", hash = "sha256:68cda27e162e9215c17d786649d1da0021a451bdc436ef9e0fa0ba5234b9b048", size = 27946, upload-time = "2024-02-04T14:48:04.179Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/1e/b832de447dee8b582cac175871d2f6c3d5077cc56d5575cadba1fd1cccfa/linkify_it_py-2.0.3-py3-none-any.whl", hash = "sha256:6bcbc417b0ac14323382aef5c5192c0075bf8a9d6b41820a2b66371eac6b6d79", size = 19820, upload-time = "2024-02-04T14:48:02.496Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
 ]
 
 [[package]]
@@ -68,6 +96,24 @@ wheels = [
 ]
 
 [[package]]
+name = "packaging"
+version = "25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
+]
+
+[[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -86,6 +132,56 @@ wheels = [
 ]
 
 [[package]]
+name = "pyinstaller"
+version = "6.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/80/9e0dad9c69a7cfd4b5aaede8c6225d762bab7247a2a6b7651e1995522001/pyinstaller-6.17.0.tar.gz", hash = "sha256:be372bd911392b88277e510940ac32a5c2a6ce4b8d00a311c78fa443f4f27313", size = 4014147, upload-time = "2025-11-24T19:43:32.109Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/f5/37e419d84d5284ecab11ef8b61306a3b978fe6f0fd69a9541e16bfd72e65/pyinstaller-6.17.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:4e446b8030c6e5a2f712e3f82011ecf6c7ead86008357b0d23a0ec4bcde31dac", size = 1031880, upload-time = "2025-11-24T19:42:30.862Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b6/2e184879ab9cf90a1d2867fdd34d507c4d246b3cc52ca05aad00bfc70ee7/pyinstaller-6.17.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:aa9fd87aaa28239c6f0d0210114029bd03f8cac316a90bab071a5092d7c85ad7", size = 731968, upload-time = "2025-11-24T19:42:35.421Z" },
+    { url = "https://files.pythonhosted.org/packages/40/76/f529de98f7e5cce7904c19b224990003fc2267eda2ee5fdd8452acb420a9/pyinstaller-6.17.0-py3-none-manylinux2014_i686.whl", hash = "sha256:060b122e43e7c0b23e759a4153be34bd70914135ab955bb18a67181e0dca85a2", size = 743217, upload-time = "2025-11-24T19:42:39.286Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/10/c02bfbb050cafc4c353cf69baf95407e211e1372bd286ab5ce5cbc13a30a/pyinstaller-6.17.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:cd213d1a545c97dfe4a3c40e8213ff7c5127fc115c49229f27a3fa541503444b", size = 741119, upload-time = "2025-11-24T19:42:43.12Z" },
+    { url = "https://files.pythonhosted.org/packages/11/9d/69fdacfd9335695f5900a376cfe3e4aed28f0720ffc15fee81fdb9d920bc/pyinstaller-6.17.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:89c0d18ba8b62c6607abd8cf2299ae5ffa5c36d8c47f39608ce8c3f357f6099f", size = 738111, upload-time = "2025-11-24T19:42:46.97Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/1e/e8e36e1568f6865ac706c6e1f875c1a346ddaa9f9a8f923d66545d2240ed/pyinstaller-6.17.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:2a147b83cdebb07855bd5a663600891550062373a2ca375c58eacead33741a27", size = 737795, upload-time = "2025-11-24T19:42:50.675Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/15/9dc0f81ccb746c27bfa6ee53164422fe47ee079c7a717d9c4791aba78797/pyinstaller-6.17.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:f8cfbbfa6708e54fb936df6dd6eafaf133e84efb0d2fe25b91cfeefa793c4ca4", size = 736891, upload-time = "2025-11-24T19:42:54.458Z" },
+    { url = "https://files.pythonhosted.org/packages/97/e6/bed54821c1ebe1275c559661d3e7bfa23c406673b515252dfbf89db56c65/pyinstaller-6.17.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:97f4c1942f7b4cd73f9e38b49cc8f5f8a6fbb44922cb60dd3073a189b77ee1ae", size = 736752, upload-time = "2025-11-24T19:42:58.144Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/84/897d759198676b910d69d42640b6d25d50b449f2209e18127a974cf59dbe/pyinstaller-6.17.0-py3-none-win32.whl", hash = "sha256:ce0be227a037fd4be672226db709088565484f597d6b230bceec19850fdd4c85", size = 1317851, upload-time = "2025-11-24T19:43:04.361Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/f5/6a122efe024433ecc34aab6f499e0bd2bbe059c639b77b0045aa2421b0bf/pyinstaller-6.17.0-py3-none-win_amd64.whl", hash = "sha256:b019940dbf7a01489d6b26f9fb97db74b504e0a757010f7ad078675befc85a82", size = 1378685, upload-time = "2025-11-24T19:43:10.395Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/96/14991773c9e599707a53594429ccf372f9ee638df3b7d26b65fd1a7433f0/pyinstaller-6.17.0-py3-none-win_arm64.whl", hash = "sha256:3c92a335e338170df7e615f75279cfeea97ade89e6dd7694943c8c185460f7b7", size = 1320032, upload-time = "2025-11-24T19:43:16.388Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2025.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/26/4f/e33132acdb8f732978e577b8a0130a412cbfe7a3414605e3fd380a975522/pyinstaller_hooks_contrib-2025.10.tar.gz", hash = "sha256:a1a737e5c0dccf1cf6f19a25e2efd109b9fec9ddd625f97f553dac16ee884881", size = 168155, upload-time = "2025-11-22T09:34:36.138Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/de/a7688eed49a1d3df337cdaa4c0d64e231309a52f269850a72051975e3c4a/pyinstaller_hooks_contrib-2025.10-py3-none-any.whl", hash = "sha256:aa7a378518772846221f63a84d6306d9827299323243db890851474dfd1231a9", size = 447760, upload-time = "2025-11-22T09:34:34.753Z" },
+]
+
+[[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "rich"
 version = "14.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -96,6 +192,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fb/d2/8920e102050a0de7bfabeb4c4614a49248cf8d5d7a8d01885fbb24dc767a/rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4", size = 219990, upload-time = "2025-10-09T14:16:53.064Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/25/7a/b0178788f8dc6cafce37a212c99565fa1fe7872c70c6c9c1e1a372d9d88f/rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd", size = 243393, upload-time = "2025-10-09T14:16:51.245Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "80.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/5d/3bf57dcd21979b887f014ea83c24ae194cfcd12b9e0fda66b957c69d1fca/setuptools-80.9.0.tar.gz", hash = "sha256:f36b47402ecde768dbfafc46e8e4207b4360c654f1f3bb84475f0a28628fb19c", size = 1319958, upload-time = "2025-05-27T00:56:51.443Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/dc/17031897dae0efacfea57dfd3a82fdd2a2aeb58e0ff71b77b87e44edc772/setuptools-80.9.0-py3-none-any.whl", hash = "sha256:062d34222ad13e0cc312a4c02d73f059e86a4acbfbdea8f8f76b28c99f306922", size = 1201486, upload-time = "2025-05-27T00:56:49.664Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces a cross-platform build and release automation workflow for the project using GitHub Actions. The main changes include adding workflows to build executables for Windows, macOS, and Linux, and to automatically attach these built assets to GitHub releases. Additionally, the project configuration is updated to support building with PyInstaller.

**Build and Release Automation:**

* Added `.github/workflows/build.yml` to automate building executables for Windows, macOS, and Linux using PyInstaller and the `uv` tool, with artifact upload for each platform.
* Added `.github/workflows/release.yml` to trigger builds on release publication and upload the built executables as assets to the corresponding GitHub release.

**Project Configuration:**

* Updated `pyproject.toml` to include a new optional dependency group `build` with `pyinstaller` for building executables.

## Human
What is tested:
- build workflow runs and builds
- release workflow calls build workflow and adds artifacts to release
- https://github.com/MOJOliciousFTW/DGsUtilityAgency/releases
<img width="2498" height="578" alt="image" src="https://github.com/user-attachments/assets/29a9bd2c-3cf4-466c-bfdb-7a1f3436b224" />
- windows artifact

What is not tested
- linux artifact
- ~~macos artifact~~

Important note:
- no signing, will raise red flags when trying to run a mysterious exe on windows. Could look into it if interest noted in #3 

closes #4 